### PR TITLE
Provide defaults in form

### DIFF
--- a/app/models/chart.rb
+++ b/app/models/chart.rb
@@ -1,6 +1,6 @@
 class Chart < ActiveRecord::Base
   has_many :data
-  accepts_nested_attributes_for :data
+  accepts_nested_attributes_for :data, allow_destroy: true
   validates :data, presence: true
 
   def gem_params

--- a/app/models/chart.rb
+++ b/app/models/chart.rb
@@ -1,14 +1,7 @@
 class Chart < ActiveRecord::Base
   has_many :data
-  accepts_nested_attributes_for :data, reject_if: :all_blank, allow_destroy: true
+  accepts_nested_attributes_for :data
   validates :data, presence: true
-
-  after_initialize :init_defaults, if: :new_record?
-  def init_defaults
-    self.background_color = '#ffffff'
-    self.style = :circle
-    self.file_type = :svg
-  end
 
   def gem_params
     {

--- a/app/models/datum.rb
+++ b/app/models/datum.rb
@@ -1,5 +1,5 @@
 class Datum < ActiveRecord::Base
   belongs_to :chart
-  validates :value, :label, presence: true
+  validates :label, :value, presence: true
   validates_numericality_of :value
 end

--- a/app/views/charts/_datum_fields.html.erb
+++ b/app/views/charts/_datum_fields.html.erb
@@ -1,6 +1,6 @@
 <tr class="nested-fields data-fields">
   <td>
-    <%= f.input :value, label: false %>
+    <%= f.input :value, label: false, as: :string %>
   </td>
   <td>
     <%= f.input :label, label: false %>

--- a/app/views/charts/_form.html.erb
+++ b/app/views/charts/_form.html.erb
@@ -16,21 +16,21 @@
       <% end %>
       <div class="well">
         <%= f.input(:title) %>
-        <%= f.input(:background_color, input_html: { class: :minicolors } ) %>
+        <%= f.input(:background_color, input_html: { class: :minicolors, value: f.object.background_color || '#ffffff' } ) %>
         <%= f.input(:columns) %>
         <%= f.input(:item_height) %>
         <%= f.input(:item_width) %>
         <%= f.input(:width) %>
         <%= f.input(:height) %>
         <%= f.input(:grouplabels) %>
-        <%= f.input(:file_type, collection: [['PNG', :png], ['SVG', :svg]]) %>
+        <%= f.input(:file_type, collection: [['PNG', :png], ['SVG', :svg]], include_blank: false) %>
         <%= f.input(:style, collection: [
           ['Circle', :circle],
           ['Cross', :cross],
           ['Manikin', :manikin],
           ['Bar', :bar],
-          ['Pie', :pie]
-        ]) %>
+          ['Pie', :pie]], include_blank: false
+        ) %>
       <%= f.submit class: 'btn btn-primary' %>
       </div>
     </div>

--- a/spec/controllers/charts_controller_spec.rb
+++ b/spec/controllers/charts_controller_spec.rb
@@ -11,20 +11,9 @@ RSpec.describe ChartsController, type: :controller do
     ])
   end
 
-  let!(:vanilla_chart) do
-    Fabricate(:chart, background_color: nil, style: 'circle', data: [
-      Fabricate(:datum, value: 1, label: 'fire' , color: nil),
-      Fabricate(:datum, value: 2, label: 'see', color: nil),
-      Fabricate(:datum, value: 3, label: 'grass', color: nil),
-      Fabricate(:datum, value: 4, label: 'sand', color: nil)
-    ])
-  end
-
+  let!(:invalid_attributes) { Fabricate.attributes_for(:chart, data_attributes: []) }  
   let(:png_chart) { Fabricate(:chart, file_type: :png) }
 
-  let(:invalid_attributes) {
-    skip('Add a hash of attributes invalid for your model')
-  }
   describe "GET #index" do
     it 'renders the index-template' do
       get :index
@@ -56,24 +45,6 @@ RSpec.describe ChartsController, type: :controller do
       it 'returns successfull status code when png-image is required' do
         get :show, id: chart.to_param
         expect(response).to be_success
-      end
-    end
-    context 'default options' do
-      it 'assigns the requested chart as @chart' do
-        get :show, id: vanilla_chart.to_param
-        expect(assigns(:charts_gem_chart).background_color).to eq('#ffffff')
-        expect(assigns(:charts_gem_chart).outer_margin).to eq(30)
-        expect(assigns(:charts_gem_chart).colors).to eq([
-          '#e41a1d',
-          '#377eb9',
-          '#4daf4b',
-          '#984ea4',
-          '#ff7f01',
-          '#ffff34',
-          '#a65629',
-          '#f781c0',
-          '#888888'
-        ])
       end
     end
   end
@@ -180,7 +151,6 @@ RSpec.describe ChartsController, type: :controller do
     end
     context 'png selected' do
       it 'responses with the correct http-header' do
-        pending('chart/after_initialize prevents fabricate from setting the necessary params')
         get :download, id: png_chart.id      
         expect(response).to be_successful
         expect(response.headers["Content-Disposition"]).to eq("attachment; filename=\"fabrication.png\"")

--- a/spec/models/chart_spec.rb
+++ b/spec/models/chart_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe Chart, type: :model do
     it 'returns options in right format' do
       expect(chart.gem_params).to eq(
         title:            'fabrication',
-        background_color: '#ffffff',
+        background_color: 'white',
         columns:          20,
         grouplabels:      ['pizza', 'pasta', 'spaghetti'],
         height:           1000,
@@ -32,7 +32,7 @@ RSpec.describe Chart, type: :model do
       bar_chart.style = :bar
       expect(bar_chart.gem_params).to eq(
         title:            'fabrication',
-        background_color: '#ffffff',
+        background_color: 'white',
         columns:          20,
         grouplabels:      ['pizza', 'pasta', 'spaghetti'],
         height:           1000,
@@ -45,15 +45,6 @@ RSpec.describe Chart, type: :model do
         labels:           ['fire', 'see', 'grass', 'sand'],
         data:             [[1.0], [2.0], [3.0], [4.0]]
       )
-    end
-  end
-
-  describe '#init_defaults' do
-    vanilla_chart = Chart.new
-    it 'returns new @chart with correct default params' do
-      expect(vanilla_chart.background_color).to eq('#ffffff')
-      expect(vanilla_chart.style).to eq('circle')
-      expect(vanilla_chart.file_type).to eq('svg')
     end
   end
 


### PR DESCRIPTION
the `init_defaults` after_initialize_hook made it hard to set up tests, because it overwrote the parameter there as well! IMO setting the Values in the form is the better approach following the slogan *what you see is what you get...* 
what do you think?